### PR TITLE
Added support for Single Group Id in config file

### DIFF
--- a/change-wallpaper.sh
+++ b/change-wallpaper.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+DIR="/tmp/wallpaper"
+PIC=$(ls $DIR/* | shuf -n1)
+gsettings set org.gnome.desktop.background picture-uri "file://$PIC"

--- a/flickr-wallpaper.py
+++ b/flickr-wallpaper.py
@@ -183,9 +183,8 @@ def set_min_upload_date(groupid):
     config.write()
 
 def get_groups():
-    config = ConfigObj(CONFIG_FILENAME)
-    return config['groups']
-
+    config = ConfigObj(CONFIG_FILENAME,list_values=False)
+    return config['groups'].split(",")
 def sanitize_filename(filename):
     import unicodedata
     validFilenameChars = "-_.() %s%s" % (string.ascii_letters, string.digits)

--- a/flickr-wallpaper.py
+++ b/flickr-wallpaper.py
@@ -185,6 +185,7 @@ def set_min_upload_date(groupid):
 def get_groups():
     config = ConfigObj(CONFIG_FILENAME,list_values=False)
     return config['groups'].split(",")
+
 def sanitize_filename(filename):
     import unicodedata
     validFilenameChars = "-_.() %s%s" % (string.ascii_letters, string.digits)


### PR DESCRIPTION
Earlier for single group id, each char was considered a group id separately.

Before:
mihir@mihir-PC:~/flickr-wallpaper$ python flickr-wallpaper.py 
Using Config file: config
Finding pictures for group: 7 since: 2016-07-17 20:11:29
Finding pictures for group: 9 since: 2016-07-17 20:11:30
Finding pictures for group: 6 since: 2016-07-17 20:11:31
Finding pictures for group: 6 since: 2016-07-17 20:24:46
Finding pictures for group: 1 since: 1969-12-31 16:00:00
Finding pictures for group: 7 since: 2016-07-17 20:24:44
Finding pictures for group: @ since: 1969-12-31 16:00:00
Finding pictures for group: N since: 1969-12-31 16:00:00
Finding pictures for group: 2 since: 1969-12-31 16:00:00
Finding pictures for group: 2 since: 2016-07-17 20:24:52
mihir@mihir-PC:~/flickr-wallpaper$

After:
mihir@mihir-PC:~/flickr-wallpaper$ python flickr-wallpaper.py 
Using Config file: config
Finding pictures for group: 796617@N22 since: 1969-12-31 16:00:00
